### PR TITLE
adding environment variable override functionality

### DIFF
--- a/catelyn/constants/cli.go
+++ b/catelyn/constants/cli.go
@@ -3,6 +3,15 @@ package constants
 const (
 	// PasswordPrompt is displayed before running any command.
 	PasswordPrompt = "password: "
+
+	// ConfluenceUsernameEnvironmentVariable is the environment variable name used for the confluence username.
+	ConfluenceUsernameEnvironmentVariable = "CONFLUENCE_USERNAME"
+
+	// ConfluencePasswordEnvironmentVariable is the environment variable name used for the confluence password.
+	ConfluencePasswordEnvironmentVariable = "CONFLUENCE_PASSWORD"
+
+	// ConfluenceHostnameEnvironmentVariable is the environment variable name used for the confluence hostname.
+	ConfluenceHostnameEnvironmentVariable = "CONFLUENCE_HOSTNAME"
 )
 
 const (

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1068090c2173da4f616937c5d908edcf1bf9ab5e9f188d509c85ec2f229b9495
-updated: 2017-11-22T15:19:27.456774657-05:00
+hash: 7c4693b5802f7f96ef6f0ada4356f37245adb6ce61e66937caabeea1ab3309f9
+updated: 2017-12-13T16:34:36.269687303-05:00
 imports:
 - name: github.com/alecthomas/kingpin
   version: 1087e65c9441605df944fb12c33f0fe7072d18ca
@@ -11,4 +11,8 @@ imports:
   version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
 - name: github.com/bgentry/speakeasy
   version: 4aabc24848ce5fd31929f7d1e4ea74d3709c14cd
+- name: github.com/chzyer/readline
+  version: 62c6fe6193755f722b8b8788aa7357be55a50ff1
+- name: github.com/joho/godotenv
+  version: a79fa1e548e2c689c241d10173efd51e5d689d5b
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,3 +6,7 @@ import:
   version: ^2.2.5
 - package: github.com/alecthomas/units
 - package: github.com/alecthomas/template
+- package: github.com/chzyer/readline
+  version: ^1.4.0
+- package: github.com/joho/godotenv
+  version: ^1.2.0

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import "io"
 import "os"
 import "fmt"
+import "github.com/joho/godotenv"
 import "github.com/bgentry/speakeasy"
 import "github.com/alecthomas/kingpin"
 import "github.com/dadleyy/catelyn/catelyn"
@@ -20,9 +21,16 @@ func main() {
 	options := catelyn.GlobalCLIOptions{}
 
 	cli := kingpin.New("catelyn", "A confluence helper")
-	cli.Flag("username", "your confluence username").Short('u').Required().StringVar(&options.ConfluenceUsername)
-	cli.Flag("hostname", "your confluence hostname").Short('h').Required().StringVar(&options.ConfluenceHost)
-	cli.Flag("password", "your confluence password").Short('p').StringVar(&options.ConfluencePassword)
+	cli.Flag("username", "confluence username").Envar(constants.ConfluenceUsernameEnvironmentVariable).
+		Short('u').Required().StringVar(&options.ConfluenceUsername)
+
+	cli.Flag("hostname", "confluence hostname").Envar(constants.ConfluenceHostnameEnvironmentVariable).
+		Short('h').Required().StringVar(&options.ConfluenceHost)
+
+	cli.Flag("password", "confluence password").Envar(constants.ConfluencePasswordEnvironmentVariable).
+		Short('p').StringVar(&options.ConfluencePassword)
+
+	godotenv.Load()
 
 	loadPassword := func(context *kingpin.ParseContext) (e error) {
 		if options.ConfluencePassword != "" {


### PR DESCRIPTION
### Notable changes

| commit/diff | reason |
| :--- | :--- |
| [`4fe4361`] | allowing environment overrides for confluence auth flags |

| [:tophat:][contributing] | @dadleyy |
| :--- | :--- |
| [:paperclip:][contributing] | |

[contributing]: https://github.com/dadleyy/catelyn/blob/master/.github/CONTRIBUTING.md
[`4fe4361`]: https://github.com/dadleyy/catelyn/commit/4fe4361f4420cf529764ecdce2c74bac5c69a19c